### PR TITLE
Add KbArticleLink for DrawingFileWithWrongConfig error

### DIFF
--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -57,6 +57,7 @@
     "ConnectorLockError": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#ConnectorLockError",
     "DatasourceAuthenticationTypeIsNotSupported": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#DatasourceAuthenticationTypeIsNotSupported",
     "DocumentNotFound": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#DocumentNotFound",
+    "DrawingFileWithWrongConfig": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#DrawingFileWithWrongConfig",
     "DuplicateData" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#DuplicateModels",
     "FailedToAccessDataSource": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#FailedToAccessDataSource",
     "FileFormat": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#fileFormat",
@@ -352,6 +353,7 @@
     "DrawingFileWithWrongConfig": {
       "description": "Do not use a 2D file as root model with sheets and drawings settings disabled.",
       "categoryId": "configuration",
+      "kbLinkId": "DrawingFileWithWrongConfig",
       "canUserFix": true
     },
     "UnmapInputFile": {


### PR DESCRIPTION
The only thing here is one KbArticleLink added to the existing standardized error for DrawingFIleWithWrongConfig