### PR TITLE
Update fatal-errors.json

### DIFF
--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -574,19 +574,19 @@
     },
     "SourceFileNotAccessible" : {
       "description": "The source file is not accessible.",
-      "categoryId": "other",
+      "categoryId": "file_access",
       "canUserFix": true,
       "kbLinkId": "SourceFileNotAccessible"
     },
     "SourceFileIsForbidden" : {
       "description": "Source file pre-authenticated URL is expired.",
-      "categoryId": "other",
+      "categoryId": "file_access",
       "canUserFix": true,
       "kbLinkId": "SourceFileIsForbidden"
     },
     "SourceFileNotFound" : {
       "description": "Source file was not found at location.",
-      "categoryId": "other",
+      "categoryId": "file_access",
       "canUserFix": true,
       "kbLinkId": "SourceFileNotFound"
     }

--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -76,7 +76,10 @@
     "UserLacksPssPermissions": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#ProductSettingPermissionsMissing",
     "UserNotAuthenticated": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#UserNotAuthenticated",
     "WorksetOverrideNotFound": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/58405/worksetoverridenotfound",
-    "ZeroByte": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#ZeroByte" 
+    "ZeroByte": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#ZeroByte",
+    "SourceFileNotAccessible": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileNotAccessible", 
+    "SourceFileIsForbidden" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileIsForbidden",
+    "SourceFileNotFound" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileNotFound"
 },
   "errors": {
     "briefcase_deleted": {
@@ -568,8 +571,25 @@
         "categoryId": "data_conflict",
         "canUserFix": true,
         "kbLinkId": ""
-
+    },
+    "SourceFileNotAccessible" : {
+      "description": "The source file is not accessible.",
+      "categoryId": "other",
+      "canUserFix": true,
+      "kbLinkId": "SourceFileNotAccessible"
+    },
+    "SourceFileIsForbidden" : {
+      "description": "Source file pre-authenticated URL is expired.",
+      "categoryId": "other",
+      "canUserFix": true,
+      "kbLinkId": "SourceFileIsForbidden"
+    },
+    "SourceFileNotFound" : {
+      "description": "Source file was not found at location.",
+      "categoryId": "other",
+      "canUserFix": true,
+      "kbLinkId": "SourceFileNotFound"
     }
-
+    
   }
 }

--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -72,15 +72,15 @@
     "ProtectedFile": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#ProtectedFile",
     "RootNotSpatial": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#RootNotSpatial",
     "SchemaUpgradeFailure": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SchemaUpgradeFailure",
+    "SourceFileIsForbidden" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileIsForbidden",
+    "SourceFileNotAccessible": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileNotAccessible", 
+    "SourceFileNotFound" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileNotFound",
     "UnmapInputFile": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#unmapInputFile",
     "UserLacksPssPermissions": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#ProductSettingPermissionsMissing",
     "UserNotAuthenticated": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#UserNotAuthenticated",
     "WorksetOverrideNotFound": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/58405/worksetoverridenotfound",
-    "ZeroByte": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#ZeroByte",
-    "SourceFileNotAccessible": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileNotAccessible", 
-    "SourceFileIsForbidden" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileIsForbidden",
-    "SourceFileNotFound" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileNotFound"
-},
+    "ZeroByte": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#ZeroByte"
+ },
   "errors": {
     "briefcase_deleted": {
       "description": "Briefcase ID %u does not exist on the server, so it cannot be restored. You must acquire a new briefcase.",


### PR DESCRIPTION
Added new errors to return specific message to user. 
This changes are related to FUKUI bug. 
[Bug 1182173](https://dev.azure.com/bentleycs/beconnect/_workitems/edit/1182173): Unclear error message when URL expires before it gets downloaded on the node