### PR TITLE
Add new error SourceFileCorrupted - ADO#1231244

### DIFF
--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -75,6 +75,7 @@
     "SourceFileIsForbidden" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileIsForbidden",
     "SourceFileNotAccessible": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileNotAccessible", 
     "SourceFileNotFound" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileNotFound",
+    "SourceFileCorrupted": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#SourceFileCorrupted",   
     "UnmapInputFile": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#unmapInputFile",
     "UserLacksPssPermissions": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#ProductSettingPermissionsMissing",
     "UserNotAuthenticated": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#UserNotAuthenticated",
@@ -589,6 +590,12 @@
       "categoryId": "file_access",
       "canUserFix": true,
       "kbLinkId": "SourceFileNotFound"
+    },
+    "SourceFileCorrupted": {
+      "description": "The input file, %s, is likely corrupted. It cannot be opened by the connector. Try auditing & recovering the file in the product that has created it.",
+      "categoryId": "file_access",
+      "kbLinkId": "SourceFileCorrupted",
+      "canUserFix": true
     }
     
   }


### PR DESCRIPTION
When a source file is so corrupted that the connector cannot open it and has to abort the process, it should send a message specifically telling the user about it