### PR TITLE
Amend error message to include root file

### DIFF
--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -494,7 +494,7 @@
       "canUserFix": false
     },
     "BriefcaseCloseAndReopenFailed": {
-      "description": "Failed to close and reopen briefcase during processing. Unable to continue processing.",
+      "description": "Failed to close and reopen root file or briefcase during processing. Unable to continue processing.",
       "categoryId": "other",
       "canUserFix": false
     },


### PR DESCRIPTION
Add the possibility that the root file did not reopen to the test for the BriefcaseCloseAndReopenFailed error. No other changes.