### PR TITLE
Add user_permission as a connector phase

### DIFF
--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -38,7 +38,8 @@
         "pull_merge_push",
         "workspace_check",
         "affinity_check",
-        "unmap"
+        "unmap",
+        "user_permission"
       ]
     }
   ],


### PR DESCRIPTION
This connector phase was found to be in use in the iModelConnectorFwk source, but not added to this repository.