### PR TITLE
Added ECEFAlreadyExistsInIModel error

### DIFF
--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -68,6 +68,7 @@
     "IModelNotFound": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#iModelName",
     "IncompleteDxfHeader" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#IncompleteDxfFile",
     "InconsistentURL" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/63085/inconsistent-url",
+    "ITwinSpatialAlignment" : "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/67080/itwin-spatial-alignment",
     "MissingShapefileDbfShx": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/48731/geoconnector#convertingShapeFiles",
     "MissingWorkspace": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#MissingWorkspace",
     "NonLinearUnits": "https://communities.bentley.com/products/digital-twin-cloud-services/itwin-services/w/synchronization-wiki/54636/knowledge-base#NonLinearUnits",
@@ -631,6 +632,7 @@
     "ECEFAlreadyExistsInIModel": {
       "description": "The iModel already contains an ECEF coordinate system. The file with the projected GCS must be imported first.",
       "categoryId": "configuration",
+      "kbLinkId": "ITwinSpatialAlignment",
       "canUserFix": true
     }
   }

--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -627,6 +627,11 @@
       "categoryId": "other",
       "kbLinkId": "",
       "canUserFix": false
+    },
+    "ECEFAlreadyExistsInIModel": {
+      "description": "The iModel already contains an ECEF coordinate system. The file with the projected GCS must be imported first.",
+      "categoryId": "configuration",
+      "canUserFix": true
     }
   }
 }


### PR DESCRIPTION
Error is needed for this item: [Bug 472533](https://dev.azure.com/bentleycs/iModelTechnologies/_workitems/edit/472533): Change the bridges to detect and reject the case where a) the input model has a projected GCS, and b) the iModel already has an ECEF