### PR TITLE
Update fatal-errors.json

### DIFF
--- a/exporter-errors/fatal-errors.json
+++ b/exporter-errors/fatal-errors.json
@@ -62,6 +62,12 @@
       "canUserFix": false,
       "kbLinkId": ""
     },
+    "InvalidUserDefinedSchemaMappingJSON" :{
+      "description": "The user-defined schema mapping JSON object is invalid.",
+      "categoryId": "download_imodel",
+      "canUserFix": true,
+      "kbLinkId": ""
+    },
     "FailedToDownloadImodel" : {
       "description": "Error occurred while downloading iModel.",
       "categoryId": "download_imodel",


### PR DESCRIPTION
I have updated the Standard Error for Invalid User-defined Schema Mapping JSON object. The Standard error description is updated dynamically when the validation fails.