### PR TITLE
New error to represent export workflow

### DIFF
--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -291,6 +291,11 @@
       "kbLinkId": "",
       "canUserFix": false
     },
+    "ExportWrapperFailed": {
+      "description": "Failed to export.",
+      "categoryId": "other",
+      "canUserFix": false
+    },
     "BridgingFailed": {
       "description": "Failed to process the file.",
       "categoryId": "other",
@@ -745,11 +750,6 @@
       "categoryId": "configuration",
       "kbLinkId": "RevitLinkIssue",
       "canUserFix": true
-    },
-    "ExportWrapperFailed": {
-      "description": "Failed to export.",
-      "categoryId": "other",
-      "canUserFix": false
     }
 
   }

--- a/fatal-errors.json
+++ b/fatal-errors.json
@@ -745,6 +745,11 @@
       "categoryId": "configuration",
       "kbLinkId": "RevitLinkIssue",
       "canUserFix": true
+    },
+    "ExportWrapperFailed": {
+      "description": "Failed to export.",
+      "categoryId": "other",
+      "canUserFix": false
     }
 
   }


### PR DESCRIPTION
Introducing new error code to represent export workflow on orchestrator. This will help to filter errors from exporter easily as a fall back when we don't receive standError.json from export.